### PR TITLE
Images and Icons in GamePanel not blurry anymore, by adding RenderOpt…

### DIFF
--- a/DlssUpdater/Controls/GamePanel.xaml
+++ b/DlssUpdater/Controls/GamePanel.xaml
@@ -9,7 +9,8 @@
     <Grid Background="#FF293038">
         <StackPanel Orientation="Horizontal">
             <Rectangle Width="100" Height="150" HorizontalAlignment="Left" VerticalAlignment="Center"
-                       Margin="10,10,10,10" Stroke="#0FFFFFFF" StrokeThickness="2">
+                       Margin="10,10,10,10" Stroke="#0FFFFFFF" StrokeThickness="2"
+                       RenderOptions.BitmapScalingMode="HighQuality">
                 <Rectangle.Fill>
                     <ImageBrush ImageSource="{Binding GameInfo.GameImage, ElementName=gamePanel}"
                                 Stretch="UniformToFill" />
@@ -23,7 +24,8 @@
                     <StackPanel Orientation="Vertical" VerticalAlignment="Bottom" HorizontalAlignment="Left">
                         <Label Content="Library" FontSize="16" HorizontalAlignment="Left" Margin="0,0,0,10"
                                VerticalAlignment="Top" Foreground="#3EFFFFFF" FontWeight="Normal" />
-                        <Rectangle Width="30" Height="30" HorizontalAlignment="Center" VerticalAlignment="Bottom">
+                        <Rectangle Width="30" Height="30" HorizontalAlignment="Center" VerticalAlignment="Bottom"                                   
+                                   RenderOptions.BitmapScalingMode="HighQuality">
                             <Rectangle.Fill>
                                 <ImageBrush ImageSource="{Binding GameInfo.LibraryImage, ElementName=gamePanel}"
                                             Stretch="Uniform" Opacity="0.5" />
@@ -78,7 +80,8 @@
                         adonisExtensions:CursorSpotlightExtension.RelativeSpotlightSize="10.0"
                         Background="#FF2E363E" Margin="0,0,0,0" Click="btnRemove_Click" />
                 <Rectangle Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Bottom"
-                           Margin="10,10,10,10" IsHitTestVisible="False">
+                           Margin="10,10,10,10" IsHitTestVisible="False"
+                           RenderOptions.BitmapScalingMode="HighQuality">
                     <Rectangle.Fill>
                         <ImageBrush ImageSource="/Icons/trashcan.png" Stretch="Uniform" Opacity="0.9" />
                     </Rectangle.Fill>
@@ -94,7 +97,8 @@
                     adonisExtensions:RippleExtension.BorderBrush="#14FFFFFF"
                     Background="#FF2E363E" Margin="0,0,0,0" Click="Button_Click" />
                 <Rectangle Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Bottom"
-                           Margin="10,10,10,10" IsHitTestVisible="False">
+                           Margin="10,10,10,10" IsHitTestVisible="False"
+                           RenderOptions.BitmapScalingMode="HighQuality">
                     <Rectangle.Fill>
                         <ImageBrush ImageSource="{Binding GameInfo.HideImage, ElementName=gamePanel}" Stretch="Uniform"
                                     Opacity="0.9" />
@@ -111,7 +115,8 @@
                     adonisExtensions:RippleExtension.BorderBrush="#14FFFFFF"
                     Background="#FF2E363E" Margin="0,0,0,0" Click="Button_Click_1" />
                 <Rectangle Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Bottom"
-                           Margin="10,10,10,10" IsHitTestVisible="False">
+                           Margin="10,10,10,10" IsHitTestVisible="False"
+                           RenderOptions.BitmapScalingMode="HighQuality">
                     <Rectangle.Fill>
                         <ImageBrush ImageSource="/Icons/config.png" Stretch="Uniform" Opacity="0.9" />
                     </Rectangle.Fill>
@@ -120,7 +125,8 @@
         </StackPanel>
 
         <Rectangle Visibility="{Binding GameInfo.UpdateVisible, ElementName=gamePanel}" Width="20" Height="20"
-                   HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,10,10,0" ToolTip="Update available">
+                   HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,10,10,0" ToolTip="Update available"
+                   RenderOptions.BitmapScalingMode="HighQuality">
             <Rectangle.Fill>
                 <ImageBrush ImageSource="/Icons/update.png" Stretch="Uniform" Opacity="0.5" />
             </Rectangle.Fill>


### PR DESCRIPTION
Remove blurriness in game's thumbnail and icons in GamePanel.